### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     extras_require={
         'msgpack': 'msgpack-python >= 0.4.6',
         'cbor': 'cbor2 ~= 4.0',
-        'yaml': 'ruamel.yaml >= 0.12',
+        'yaml': 'ruamel.yaml >= 0.12, < 0.15',
         'testing': [
             'pytest',
             'pytest-cov',


### PR DESCRIPTION
Thank you for using ruamel.yaml.

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your user could see.
Therefore please release a version of your package with this change, so that it will not
automatically take the latest ruamel.yaml release.